### PR TITLE
refactor: Abstract config default logic into SetDefaults method

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,5 +1,11 @@
 package config
 
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
 type (
 	Server struct {
 		Host string `env:"host"`
@@ -16,3 +22,17 @@ type (
 		DB          DB          `env:"db"`
 	}
 )
+
+// SetDefaults sets default values for configuration fields if they are not already set.
+// Specifically, it sets a default database path if `DB.Path` is empty.
+func (c *Config) SetDefaults() error {
+	if c.DB.Path == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("failed to get user home directory: %w", err)
+		}
+		defaultDBPath := filepath.Join(homeDir, ".cardmax", "data.db")
+		c.DB.Path = defaultDBPath
+	}
+	return nil
+}


### PR DESCRIPTION
Moved the logic for setting default configuration values (starting with the DB path) from main.go into a `SetDefaults` method on the Config struct within the config package.

This improves separation of concerns and makes it easier to add more default configuration values in the future without cluttering the main application setup in main.go.

main.go has been updated to call this new method after reading the initial configuration from environment variables.