### PR TITLE
feat: Use UPSERT for predefined cards

### DIFF
--- a/internal/db/models/predefined_cards.sql.gen.go
+++ b/internal/db/models/predefined_cards.sql.gen.go
@@ -30,7 +30,17 @@ INSERT INTO predefined_cards (
     ?, -- point_value
     ?, -- annual_fee
     ? -- annual_fee_waiver
-) RETURNING id, card_key, name, issuer, card_type, default_reward_rate, reward_type, point_value, annual_fee, annual_fee_waiver, created_at, updated_at
+)
+ON CONFLICT (card_key) DO UPDATE SET
+    name = excluded.name,
+    issuer = excluded.issuer,
+    card_type = excluded.card_type,
+    default_reward_rate = excluded.default_reward_rate,
+    reward_type = excluded.reward_type,
+    point_value = excluded.point_value,
+    annual_fee = excluded.annual_fee,
+    annual_fee_waiver = excluded.annual_fee_waiver
+RETURNING id, card_key, name, issuer, card_type, default_reward_rate, reward_type, point_value, annual_fee, annual_fee_waiver, created_at, updated_at
 `
 
 type CreatePredefinedCardParams struct {

--- a/internal/db/predefined_cards.go
+++ b/internal/db/predefined_cards.go
@@ -2,8 +2,6 @@ package db
 
 import (
 	"context"
-	"database/sql"
-	"errors"
 	"fmt"
 	"github.com/pushkar-anand/build-with-go/logger"
 	"github.com/pushkar-anand/cardmax/internal/cards"
@@ -36,7 +34,7 @@ func (d *DB) PopulatePredefinedCards(ctx context.Context, log *slog.Logger, card
 	for _, card := range cardList {
 		var (
 			dbCard *models.PredefinedCard
-			err error
+			err    error
 		)
 
 		// Upsert the card (insert or update on conflict)

--- a/internal/db/predefined_cards.go
+++ b/internal/db/predefined_cards.go
@@ -36,48 +36,40 @@ func (d *DB) PopulatePredefinedCards(ctx context.Context, log *slog.Logger, card
 	for _, card := range cardList {
 		var (
 			dbCard *models.PredefinedCard
-			err    error
+			err error
 		)
 
-		// Check if the card already exists
-		dbCard, err = q.GetPredefinedCardByKey(ctx, card.Key)
-		if err != nil && errors.Is(err, sql.ErrNoRows) {
-
-			// Card doesn't exist, create it
-			var annualFeeWaiver *string
-			if card.AnnualFeeWaiver != "" {
-				annualFeeWaiver = &card.AnnualFeeWaiver
-			}
-
-			newCard, err := q.CreatePredefinedCard(ctx, models.CreatePredefinedCardParams{
-				CardKey:           card.Key,
-				Name:              card.Name,
-				Issuer:            card.Issuer,
-				CardType:          card.CardType,
-				DefaultRewardRate: card.DefaultRewardRate,
-				RewardType:        card.RewardType,
-				PointValue:        card.PointValue,
-				AnnualFee:         int64(card.AnnualFee),
-				AnnualFeeWaiver:   annualFeeWaiver,
-			})
-
-			dbCard = newCard
-
-			if err != nil {
-				return fmt.Errorf("failed to create predefined card %s: %w", card.Key, err)
-			}
-
-			log.InfoContext(ctx, "created predefined card in database",
-				slog.String("key", card.Key),
-				slog.String("name", card.Name),
-				slog.String("issuer", card.Issuer))
+		// Upsert the card (insert or update on conflict)
+		var annualFeeWaiver *string
+		if card.AnnualFeeWaiver != "" {
+			annualFeeWaiver = &card.AnnualFeeWaiver
 		}
 
-		if err != nil && !errors.Is(err, sql.ErrNoRows) {
-			return fmt.Errorf("error checking if predefined card exists %s: %w", card.Key, err)
+		dbCard, err = q.CreatePredefinedCard(ctx, models.CreatePredefinedCardParams{
+			CardKey:           card.Key,
+			Name:              card.Name,
+			Issuer:            card.Issuer,
+			CardType:          card.CardType,
+			DefaultRewardRate: card.DefaultRewardRate,
+			RewardType:        card.RewardType,
+			PointValue:        card.PointValue,
+			AnnualFee:         int64(card.AnnualFee),
+			AnnualFeeWaiver:   annualFeeWaiver,
+		})
+
+		if err != nil {
+			return fmt.Errorf("failed to upsert predefined card %s: %w", card.Key, err)
 		}
+
+		log.InfoContext(ctx, "upserted predefined card in database",
+			slog.String("key", dbCard.CardKey), // Use dbCard.CardKey here as it's returned by the query
+			slog.String("name", dbCard.Name),
+			slog.String("issuer", dbCard.Issuer))
 
 		// Add reward rules for this card
+		// TODO: Consider if reward rules also need upsert logic or deletion of old rules.
+		// For now, we'll add them. If the card exists, this might create duplicate rules
+		// if CreatePredefinedRewardRule doesn't handle conflicts.
 		for _, rule := range card.RewardRules {
 			_, err := q.CreatePredefinedRewardRule(ctx, models.CreatePredefinedRewardRuleParams{
 				PredefinedCardID: dbCard.ID,

--- a/internal/db/queries/predefined_cards.sql
+++ b/internal/db/queries/predefined_cards.sql
@@ -19,7 +19,17 @@ INSERT INTO predefined_cards (
     ?, -- point_value
     ?, -- annual_fee
     ? -- annual_fee_waiver
-) RETURNING *;
+)
+ON CONFLICT (card_key) DO UPDATE SET
+    name = excluded.name,
+    issuer = excluded.issuer,
+    card_type = excluded.card_type,
+    default_reward_rate = excluded.default_reward_rate,
+    reward_type = excluded.reward_type,
+    point_value = excluded.point_value,
+    annual_fee = excluded.annual_fee,
+    annual_fee_waiver = excluded.annual_fee_waiver
+RETURNING *;
 
 -- name: GetPredefinedCardByKey :one
 SELECT * FROM predefined_cards


### PR DESCRIPTION
Refactors the logic for populating predefined card data to use SQLite's `INSERT ... ON CONFLICT DO UPDATE` (UPSERT) functionality.

This replaces the previous approach of performing a SELECT query followed by an INSERT query, making the process more efficient.

Changes include:
- Modified `CreatePredefinedCard` query in `internal/db/queries/predefined_cards.sql` to use UPSERT targeting the `card_key`.
- Updated `PopulatePredefinedCards` function in `internal/db/predefined_cards.go` to remove the SELECT check and directly call the modified `CreatePredefinedCard` (UPSERT) function.

Note: After pulling these changes, run `go generate ./...` or `make gen` to regenerate the SQLC code (`*.sql.gen.go` files) based on the updated SQL query.