### PR TITLE
feat: Use UPSERT for predefined reward rules

### DIFF
--- a/internal/db/migrations/000003_unique_reward_rules.down.sql
+++ b/internal/db/migrations/000003_unique_reward_rules.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX idx_unique_reward_rule;

--- a/internal/db/migrations/000003_unique_reward_rules.up.sql
+++ b/internal/db/migrations/000003_unique_reward_rules.up.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX idx_unique_reward_rule ON predefined_reward_rules (predefined_card_id, type, entity_name);

--- a/internal/db/models/predefined_cards.sql.gen.go
+++ b/internal/db/models/predefined_cards.sql.gen.go
@@ -98,7 +98,11 @@ INSERT INTO predefined_reward_rules (
     ?, -- entity_name
     ?, -- reward_rate
     ? -- reward_type
-) RETURNING id, predefined_card_id, type, entity_name, reward_rate, reward_type, created_at, updated_at
+)
+ON CONFLICT (predefined_card_id, type, entity_name) DO UPDATE SET
+    reward_rate = excluded.reward_rate,
+    reward_type = excluded.reward_type
+RETURNING id, predefined_card_id, type, entity_name, reward_rate, reward_type, created_at, updated_at
 `
 
 type CreatePredefinedRewardRuleParams struct {

--- a/internal/db/queries/predefined_cards.sql
+++ b/internal/db/queries/predefined_cards.sql
@@ -19,7 +19,17 @@ INSERT INTO predefined_cards (
     ?, -- point_value
     ?, -- annual_fee
     ? -- annual_fee_waiver
-) RETURNING *;
+)
+ON CONFLICT (card_key) DO UPDATE SET
+    name = excluded.name,
+    issuer = excluded.issuer,
+    card_type = excluded.card_type,
+    default_reward_rate = excluded.default_reward_rate,
+    reward_type = excluded.reward_type,
+    point_value = excluded.point_value,
+    annual_fee = excluded.annual_fee,
+    annual_fee_waiver = excluded.annual_fee_waiver
+RETURNING *;
 
 -- name: GetPredefinedCardByKey :one
 SELECT * FROM predefined_cards
@@ -43,7 +53,11 @@ INSERT INTO predefined_reward_rules (
     ?, -- entity_name
     ?, -- reward_rate
     ? -- reward_type
-) RETURNING *;
+)
+ON CONFLICT (predefined_card_id, type, entity_name) DO UPDATE SET
+    reward_rate = excluded.reward_rate,
+    reward_type = excluded.reward_type
+RETURNING *;
 
 -- name: GetPredefinedRewardRulesByCardID :many
 SELECT * FROM predefined_reward_rules


### PR DESCRIPTION
Adds UPSERT functionality for predefined reward rules, complementing the previous changes for predefined cards.

This ensures that reward rules associated with predefined cards are correctly inserted or updated when populating data.

Changes include:
- Added migration `000003_unique_reward_rules` to create a unique index on (`predefined_card_id`, `type`, `entity_name`) in the `predefined_reward_rules` table. This is necessary for the UPSERT conflict target.
- Modified `CreatePredefinedRewardRule` query in `internal/db/queries/predefined_cards.sql` to use `INSERT ... ON CONFLICT DO UPDATE` targeting the new unique index.
- Removed a TODO comment in `internal/db/predefined_cards.go` as the UPSERT logic now handles potential duplicate rules.

Manual steps required after pulling:
1. Apply database migrations (e.g., `migrate up`).
2. Regenerate SQLC code (e.g., `go generate ./...` or `make gen`).